### PR TITLE
fix: compile native deps

### DIFF
--- a/src/jobs/build_test.yml
+++ b/src/jobs/build_test.yml
@@ -7,6 +7,9 @@ executor:
 
 steps:
   - checkout
+  - run:
+      name: Ensure priv dir exists
+      command: mkdir -p priv
   - get_mix_deps
   - use_build_cache:
       env: test

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -7,6 +7,9 @@ executor:
 
 steps:
   - checkout
+  - run:
+      name: Ensure priv dir exists
+      command: mkdir -p priv
   - get_mix_deps
   - use_build_cache:
       env: dev

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -7,6 +7,9 @@ executor:
 
 steps:
   - checkout
+  - run:
+      name: Ensure priv dir exists
+      command: mkdir -p priv
   - get_mix_deps
   - use_build_cache:
       env: test

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -11,5 +11,8 @@ steps:
   - use_build_cache:
       env: test
   - run:
+      name: Ensure native deps are compiled
+      command: mix deps.compile
+  - run:
       name: Run all tests
       command: mix test --warnings-as-errors


### PR DESCRIPTION
1. Bundlex sometimes requires `priv` dir at top level, but tries to create it via broken symlink
2. Native deps artefacts are stored under `dep/[dependancy_name]/priv` and symlinked in `_build` so the cache is broken. Workaround re-runs `mix deps.compile` to recreate artefacts under deps.