### PR TITLE
Automated hex publish

### DIFF
--- a/src/jobs/hex_publish.yml
+++ b/src/jobs/hex_publish.yml
@@ -7,9 +7,6 @@ executor:
 
 steps:
   - checkout
-  - run:
-      name: Ensure priv dir exists
-      command: mkdir -p priv
   - get_mix_deps
   - use_build_cache:
       env: test


### PR DESCRIPTION
This PR adds a `hex_publish` job, which publishes the package to hex under the `membraneframework` organization.