### PR TITLE
Fix grep matching when uninstalling unwanted deps

### DIFF
--- a/src/scripts/precompile_for_linux.sh
+++ b/src/scripts/precompile_for_linux.sh
@@ -13,7 +13,7 @@ done
 brew install $PACKAGE_NAME
 for pkg in "${unwanted_deps[@]}"
 do
-    if brew list | grep -q "^${pkg}$"
+    if brew list | grep -q "^${pkg}"
     then
         brew uninstall --ignore-dependencies --force $pkg
     fi

--- a/src/scripts/precompile_for_linux.sh
+++ b/src/scripts/precompile_for_linux.sh
@@ -13,7 +13,7 @@ done
 brew install $PACKAGE_NAME
 for pkg in "${unwanted_deps[@]}"
 do
-    if brew list | grep -q "^${pkg}"
+    if brew list | grep -q "^${pkg}($|@)"
     then
         brew uninstall --ignore-dependencies --force $pkg
     fi

--- a/src/scripts/precompile_for_macos.sh
+++ b/src/scripts/precompile_for_macos.sh
@@ -14,7 +14,7 @@ done
 brew install $PACKAGE_NAME
 for pkg in "${unwanted_deps[@]}"
 do
-    if brew list | grep -q "^${pkg}"
+    if brew list | grep -q "^${pkg}($|@)"
     then
         brew uninstall --ignore-dependencies --force $pkg
     fi

--- a/src/scripts/precompile_for_macos.sh
+++ b/src/scripts/precompile_for_macos.sh
@@ -14,7 +14,7 @@ done
 brew install $PACKAGE_NAME
 for pkg in "${unwanted_deps[@]}"
 do
-    if brew list | grep -q "^${pkg}$"
+    if brew list | grep -q "^${pkg}"
     then
         brew uninstall --ignore-dependencies --force $pkg
     fi


### PR DESCRIPTION
exact matching for start and end of line caused versioned packages to not be detected, for example `grep ^openssl$` doesn't detect `openssl@3`