### PR TITLE
Get version from brew info rather than brew list

### DIFF
--- a/src/scripts/precompile_for_macos.sh
+++ b/src/scripts/precompile_for_macos.sh
@@ -7,6 +7,12 @@ esac
 mkdir -p ~/project/workspace/$artifact_name/include
 mkdir -p ~/project/workspace/$artifact_name/lib
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+real_version="v$(brew info $PACKAGE_NAME | head -1 | cut -d ' ' -f 4)"
+if [[ ! $EXPECTED_VERSION =~ ^($real_version|"no check")$ ]]
+then
+    echo "Version passed via tag: $EXPECTED_VERSION not matching installed version: $real_version"
+    exit 1
+fi  
 for pkg in $(brew list)
 do
     brew uninstall --ignore-dependencies --force $pkg 
@@ -19,12 +25,6 @@ do
         brew uninstall --ignore-dependencies --force $pkg
     fi
 done
-real_version="v$(brew list --versions | grep -w $PACKAGE_NAME | cut -d ' ' -f 2)"
-if [[ ! $EXPECTED_VERSION =~ ^($real_version|"no check")$ ]]
-then
-    echo "Version passed via tag: $EXPECTED_VERSION not matching installed version: $real_version"
-    exit 1
-fi  
 cp -r ${brew_prefix}/include/* ~/project/workspace/$artifact_name/include
 
 cd "${brew_prefix}"/lib || exit 1


### PR DESCRIPTION
Getting version provided by `brew info` is much more accessible by the user, since running `brew list` actually requires you to have that package installed. Additionally, if the user doesn't have brew, the version from `brew info` matches the one on the formula's website